### PR TITLE
pcolormesh class added

### DIFF
--- a/lib/cube_browser/__init__.py
+++ b/lib/cube_browser/__init__.py
@@ -35,7 +35,6 @@ class Pyplot(object):
         self.coords = coords  # coords to plot as x, y
         self.kwargs = kwargs
         self.axes = self.new_axes()
-        self.qcs = None  # QuadContourSet
         # A mapping of 1d-coord name to dimension
         self.coord_dim = self.coord_dims()
 
@@ -113,6 +112,7 @@ class Contourf(Pyplot):
 
         """
         cube = self._get_slice(coord_values)
+        # Add QuadContourSet to self
         self.qcs = iplt.contourf(cube, coords=self.coords,
                                  axes=self.axes, **self.kwargs)
         return plt.gca()
@@ -152,6 +152,7 @@ class Contour(Pyplot):
 
         """
         cube = self._get_slice(coord_values)
+        # Add QuadContourSet to self
         self.qcs = iplt.contour(cube, coords=self.coords,
                                 axes=self.axes, **self.kwargs)
         return plt.gca()
@@ -188,9 +189,8 @@ class Pcolormesh(Pyplot):
 
         """
         cube = self._get_slice(coord_values)
-        # XXX: This uses a QuadMesh, not a QuadContourSet.
-        # Do I change this here?
-        self.qcs = iplt.pcolormesh(cube, coords=self.coords,
+        # Add QuadMesh to self
+        self.qm = iplt.pcolormesh(cube, coords=self.coords,
                                 axes=self.axes, **self.kwargs)
         return plt.gca()
 

--- a/lib/cube_browser/__init__.py
+++ b/lib/cube_browser/__init__.py
@@ -157,6 +157,44 @@ class Contour(Pyplot):
         return plt.gca()
 
 
+class Pcolormesh(Pyplot):
+    """
+    Constructs a pseduocolour plot instance of a cube on a quadrilateral mesh.
+
+    An :func:`iris.plot.pcolormesh` instance is created using coordinates
+    specified in the input arguments as axes coordinates.
+
+    See :func:`matplotlib.pyplot.pcolormesh` and :func:`iris.plot.pcolormesh`
+    for details of other valid keyword arguments.
+
+    """
+
+    # XXX: #24: coord_values is under review to be changed to a list or
+    # dictionary or something
+    # NOTE: Currently, Browser supplies a dictionary here.
+    def __call__(self, **coord_values):
+        """
+        Constructs a static plot of the cube sliced at the coordinates
+        specified in coord_values.
+
+        This is called once each time a slider position is moved, at which
+        point the new coordinate values are plotted.
+
+        Args:
+
+        * coord_values
+            Mapping dictionary of coordinate name or dimension
+            index with value index at which to be sliced.
+
+        """
+        cube = self._get_slice(coord_values)
+        # XXX: This uses a QuadMesh, not a QuadContourSet.
+        # Do I change this here?
+        self.qcs = iplt.pcolormesh(cube, coords=self.coords,
+                                axes=self.axes, **self.kwargs)
+        return plt.gca()
+
+
 class Browser(object):
     """
     Compiler for cube_browser plots and associated sliders.

--- a/lib/cube_browser/tests/unit/test_Pcolormesh.py
+++ b/lib/cube_browser/tests/unit/test_Pcolormesh.py
@@ -9,7 +9,7 @@ import iris.tests as tests
 from iris.tests.stock import realistic_3d
 
 from cartopy.mpl.geoaxes import GeoAxesSubplot
-from matplotlib.pcolormesh import QuadMesh
+from matplotlib.collections import QuadMesh
 from cube_browser import Pcolormesh
 
 

--- a/lib/cube_browser/tests/unit/test_Pcolormesh.py
+++ b/lib/cube_browser/tests/unit/test_Pcolormesh.py
@@ -1,0 +1,29 @@
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+"""Unit tests for the `cube_browser.Pcolormesh` class."""
+
+# Import iris.tests first so that some things can be initialised
+# before importing anything else.
+import iris.tests as tests
+
+from iris.tests.stock import realistic_3d
+
+from cartopy.mpl.geoaxes import GeoAxesSubplot
+from matplotlib.pcolormesh import QuadMesh
+from cube_browser import Pcolormesh
+
+
+class Test__call__(tests.IrisTest):
+    def setUp(self):
+        self.cube = realistic_3d()
+        self.pcoords = ('grid_longitude',
+                        'grid_latitude')  # plot axis coordinates.
+
+    def test_plot_type(self):
+        pcm = Pcolormesh(self.cube, self.pcoords)
+        ax = pcm(time=0)
+        self.assertTrue(isinstance(ax, GeoAxesSubplot))
+        self.assertTrue(isinstance(pcm.qm, QuadMesh))
+
+if __name__ == '__main__':
+    tests.main()


### PR DESCRIPTION
Method works, but I am not entirely happy that it contains the variable on line 193 called self.qcs (quad contour set) when it actually uses a quad mesh.

This will have to be changed at some point for clarity and accuracy, but as far as functionality is concerned, this is a trivial issue and makes no difference to the outcome of the call.