### PR TITLE
Weak reference cube plot cache.

### DIFF
--- a/lib/cube_browser/__init__.py
+++ b/lib/cube_browser/__init__.py
@@ -418,7 +418,8 @@ class Browser(object):
         self.plot = plot
         # Mapping of cube id to shared cache.
         self._cache_by_cube_id = {}
-        self._build_mappings()
+        # XXX: can't integrate this quite yet, as require multi-plot support ...
+#        self._build_mappings()
         self._sliders = {}
         for coord in plot.slider_coords():
                 slider = ipywidgets.IntSlider(min=0, max=coord.shape[0] - 1,
@@ -431,14 +432,14 @@ class Browser(object):
         self.on_change(None)
         IPython.display.display(self.form)
 
-    def _build_mappings(self):
-        for plot in self.plots:
-            cube_id = id(plot.cube)
-            cache = self._cache_by_cube_id.get(cube_id)
-            if cache is None:
-                self._cache_by_cube_id[cube_id] = plot.cache
-            else:
-                plot.cache = cache
+    # def _build_mappings(self):
+    #     for plot in self.plots:
+    #         cube_id = id(plot.cube)
+    #         cache = self._cache_by_cube_id.get(cube_id)
+    #         if cache is None:
+    #             self._cache_by_cube_id[cube_id] = plot.cache
+    #         else:
+    #             plot.cache = cache
 
     def on_change(self, change):
         """

--- a/lib/cube_browser/__init__.py
+++ b/lib/cube_browser/__init__.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 import six
 
+from weakref import WeakValueDictionary
+
 import IPython
 import ipywidgets
 from iris.coords import Coord, DimCoord
@@ -41,6 +43,8 @@ class Pyplot(object):
 
         """
         self.cube = cube
+        #: The latest rendered cube slice.
+        self.subcube = None
         if cube.ndim < 2:
             emsg = '{} requires at least a 2d cube, got {}d.'
             raise ValueError(emsg.format(type(self).__name__, cube.ndim))
@@ -57,6 +61,8 @@ class Pyplot(object):
         self.element = None
         # A mapping of dimension alias name to dimension.
         self._dim_by_alias = {}
+        # A weak reference value cache for plot sub-cubes.
+        self._cache = None
 
     def _default_coords(self):
         """
@@ -217,14 +223,30 @@ class Pyplot(object):
                     raise ValueError(emsg.format(name, dim, dims[0]))
             self._dim_by_alias[name] = dim
 
+    @property
+    def cache(self):
+        if self._cache is None:
+            self._cache = WeakValueDictionary()
+        return self._cache
+
+    @cache.setter
+    def cache(self, value):
+        if not isinstance(value, WeakValueDictionary):
+            emsg = "Require cache to be a {!r}, got {!r}."
+            raise TypeError(emsg.format(WeakValueDictionary.__name__,
+                                        type(value).__name__))
+        self._cache = value
+
     def _get_slice(self, coord_values):
         index = [slice(None)] * self.cube.ndim
         for name, value in coord_values.items():
             if name in self.coord_dim:
                 index[self.coord_dim[name]] = value
-        cube = self.cube[tuple(index)]
-        plt.sca(self.axes)
-        return cube
+        index = tuple(index)
+        key = tuple(sorted(coord_values.items()))
+        # A primative weak reference cache.
+        self.subcube = self.cache.setdefault(key, self.cube[index])
+        return self.subcube
 
     def coord_dims(self):
         """
@@ -394,6 +416,9 @@ class Browser(object):
 
         """
         self.plot = plot
+        # Mapping of cube id to shared cache.
+        self._cache_by_cube_id = {}
+        self._build_mappings()
         self._sliders = {}
         for coord in plot.slider_coords():
                 slider = ipywidgets.IntSlider(min=0, max=coord.shape[0] - 1,
@@ -405,6 +430,15 @@ class Browser(object):
         # This bit displays the slider and the plot.
         self.on_change(None)
         IPython.display.display(self.form)
+
+    def _build_mappings(self):
+        for plot in self.plots:
+            cube_id = id(plot.cube)
+            cache = self._cache_by_cube_id.get(cube_id)
+            if cache is None:
+                self._cache_by_cube_id[cube_id] = plot.cache
+            else:
+                plot.cache = cache
 
     def on_change(self, change):
         """

--- a/lib/cube_browser/tests/unit/test_Pyplot.py
+++ b/lib/cube_browser/tests/unit/test_Pyplot.py
@@ -6,6 +6,8 @@ from six.moves import (filter, input, map, range, zip)  # noqa
 # before importing anything else.
 import iris.tests as tests
 
+from weakref import WeakValueDictionary
+
 import iris.plot
 from iris.coords import AuxCoord
 from iris.tests.stock import realistic_3d
@@ -334,6 +336,36 @@ class Test_aliases(tests.IrisTest):
             plot.alias(**{name: dim})
         self.assertEqual(plot.aliases, expected)
         self.assertIsNot(plot.aliases, plot._dim_by_alias)
+
+class Test_cache(tests.IrisTest):
+    def setUp(self):
+        cube = realistic_3d()
+        axes = tests.mock.sentinel.axes
+        self.plot = Pyplot(cube, axes)
+
+    def test_cache_create(self):
+        self.assertIsNone(self.plot._cache)
+        cache = self.plot.cache
+        self.assertIsInstance(cache, WeakValueDictionary)
+        self.assertEqual(cache, {})
+
+    def test_bad_cache_setter(self):
+        emsg = ("Require cache to be a 'WeakValueDictionary', "
+                "got 'dict'")
+        with self.assertRaisesRegexp(TypeError, emsg):
+            self.plot.cache = dict()
+
+    def test_cache_lookup(self):
+        index = 0
+        kwargs = dict(time=index)
+        subcube = self.plot._get_slice(kwargs)
+        expected = self.plot.cube[index]
+        self.assertEqual(subcube, expected)
+        self.assertEqual(self.plot.subcube, expected)
+        cache = self.plot.cache
+        key = tuple(sorted(kwargs.items()))
+        self.assertIn(key, cache)
+        self.assertEqual(cache[key], expected)
 
 
 class Test_coord_dims(tests.IrisTest):

--- a/lib/cube_browser/tests/unit/test_Pyplot.py
+++ b/lib/cube_browser/tests/unit/test_Pyplot.py
@@ -8,10 +8,8 @@ import iris.tests as tests
 
 from weakref import WeakValueDictionary
 
-import iris.plot
 from iris.coords import AuxCoord
 from iris.tests.stock import realistic_3d
-import matplotlib.pyplot as plt
 import numpy as np
 
 from cube_browser import Pyplot


### PR DESCRIPTION
Implements a primitive weak reference value cache for plot sub-cubes.

The **same** cache is shared between **different** (sub-)plots that reference the **same** cube. This means that a cube is only sliced and loaded **once** for different plots that reference the **same** cube and that require the **same** slice.

Weak references rely on the Python interpreter garbage collector tidying up any variables with no reference counts, so once a variable (i.e. cache item) is no longer used (referenced) it is deleted (garbage collected) by Python for free.

This is a really cheap efficiency win.