### PR TITLE
conda install guide

### DIFF
--- a/doc/explorers/intro.rst
+++ b/doc/explorers/intro.rst
@@ -25,7 +25,7 @@ To download the notebook, you will need an environment which possesses the requi
 The installation instructions on the `homepage<index.html>`_ will provide this capability.
 Make sure you have a terminal with the Cube Browser environment activated, change directory to the location of your downloaded notebook, and then type:
 
-`jupyter notebook`
+``jupyter notebook``
 
 This will open a notebook tree from which you can access your Explorer.
 Once you have opened it, you can follow the steps above for running the notebook from your browser.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,9 +34,24 @@ There are three different ways which you can use Cube Browser:
 Installation
 ____________
 
-Conda is great
+In the following pages you will find downloads of Jupyter notebooks containing Cube Browser operations.
+To be able to use these notebooks, you will need to configure your environment correctly.
+The most efficient and clean method to do this is to use a Conda environment (please see `Anaconda website <https://anaconda.org/>`_ for help and information).
 
-------------
+If you have never used Conda before, you will need to follow these `quick installation instructions <http://conda.pydata.org/docs/install/quick.html>`_ to get started.
+
+Once you have done this, open a terminal and type:
+
+``conda create -n cb -c scitools``
+
+This will create your environment to the specific requirements necessary to run Cube Browser.
+To activate that environment, type:
+
+``. activate cb``
+
+*Please Note:* This will only make the Cube Browser environment active in the current terminal.
+When you wish to use Cube Browser, you will have to run from a terminal in which the environment is active.
+
 
 Support
 _______

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,7 @@ ____________
 
 In the following pages you will find downloads of Jupyter notebooks containing Cube Browser operations.
 To be able to use these notebooks, you will need to configure your environment correctly.
-The most efficient and clean method to do this is to use a Conda environment (please see `Anaconda website <https://anaconda.org/>`_ for help and information).
+The most efficient and clean method to do this is to use a Conda environment (please see Anaconda website for help and information).
 
 If you have never used Conda before, you will need to follow these `quick installation instructions <http://conda.pydata.org/docs/install/quick.html>`_ to get started.
 
@@ -45,12 +45,15 @@ Once you have done this, open a terminal and type:
 ``conda create -n cb -c scitools``
 
 This will create your environment to the specific requirements necessary to run Cube Browser.
-To activate that environment, type:
+To activate that environment, if you are using a Windows machine, type:
 
-``. activate cb``
+``activate cb``
 
-*Please Note:* This will only make the Cube Browser environment active in the current terminal.
-When you wish to use Cube Browser, you will have to run from a terminal in which the environment is active.
+Alternatively, if you are using Linux, type:
+
+``source activate cb``
+
+*Please Note:* When you wish to use Cube Browser, you must initiate a notebook from a terminal in which the cb environment is active.
 
 
 Support

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,7 +42,7 @@ If you have never used Conda before, you will need to follow these `quick instal
 
 Once you have done this, open a terminal and type:
 
-``conda install -c scitools -c conda-forge -c scitools/label/dev cube_browser``
+``conda install -c scitools -c conda-forge -c scitools/label/dev python=2.7 cube_browser``
 
 This will install Cube Browser with the specific requirements necessary to run it.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,24 +36,15 @@ ____________
 
 In the following pages you will find downloads of Jupyter notebooks containing Cube Browser operations.
 To be able to use these notebooks, you will need to configure your environment correctly.
-The most efficient and clean method to do this is to use a Conda environment (please see Anaconda website for help and information).
+The most efficient and clean method to do this is to use a Conda environment.
 
 If you have never used Conda before, you will need to follow these `quick installation instructions <http://conda.pydata.org/docs/install/quick.html>`_ to get started.
 
 Once you have done this, open a terminal and type:
 
-``conda create -n cb -c scitools``
+``conda install -c scitools -c conda-forge -c scitools/label/dev cube_browser``
 
-This will create your environment to the specific requirements necessary to run Cube Browser.
-To activate that environment, if you are using a Windows machine, type:
-
-``activate cb``
-
-Alternatively, if you are using Linux, type:
-
-``source activate cb``
-
-*Please Note:* When you wish to use Cube Browser, you must initiate a notebook from a terminal in which the cb environment is active.
+This will install Cube Browser with the specific requirements necessary to run it.
 
 
 Support


### PR DESCRIPTION
Text added to 'Installation' section of homepage to instruct users how to set up and activate the Cube Browser environment, with links to conda install guide and Anaconda homepage.